### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -56,14 +56,14 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
         working-directory: ${{ env.BUILD_PATH }}
@@ -74,7 +74,7 @@ jobs:
             --base "${{ steps.pages.outputs.base_path }}"
         working-directory: ${{ env.BUILD_PATH }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ env.BUILD_PATH }}/dist
 
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` from v4 to v7
- Upgrade `actions/setup-node` from v4 to v7
- Upgrade `actions/configure-pages` from v4 to v6
- Upgrade `actions/upload-pages-artifact` from v3 to v5
- Upgrade `actions/deploy-pages` from v4 to v5

## Why

The site build already uses Node.js 24, but the older action releases bundled Node.js 20 runtimes. GitHub therefore emitted Node.js 20 deprecation warnings during Pages deployments.

The selected releases use Node.js 24. `upload-pages-artifact@v5` delegates to the Node.js 24-compatible `upload-artifact@v7`.

## Impact

Future Pages deployments should run entirely on Node.js 24 without the action-runtime deprecation warnings. The site build and deployment structure are otherwise unchanged.

## Validation

- Clean dependency installation with Node.js 24
- Full production build: 92 pages generated successfully
- Pagefind index: 86 pages indexed successfully
- Workflow YAML parsed successfully
- `git diff --check` passed